### PR TITLE
Support transient property as sectionName

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		14F848891CC668B60052E4B0 /* DATASource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14308A9F1CC66665000C21DF /* DATASource.swift */; };
 		14F8488A1CC668B60052E4B0 /* DATASourceCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14308AA01CC66665000C21DF /* DATASourceCollectionHeaderView.swift */; };
 		14F8488B1CC668B60052E4B0 /* DATASourceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14308AA11CC66665000C21DF /* DATASourceDelegate.swift */; };
+		7207A0CA1CEA34E9005FDD4C /* User+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7207A0C81CEA34E9005FDD4C /* User+CoreDataProperties.swift */; };
+		7207A0CB1CEA34E9005FDD4C /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7207A0C91CEA34E9005FDD4C /* User.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -315,6 +317,8 @@
 		14F8486F1CC667BB0052E4B0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14F848701CC667D20052E4B0 /* DATASource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DATASource.h; sourceTree = "<group>"; };
 		14F8487D1CC668820052E4B0 /* DATASource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DATASource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7207A0C81CEA34E9005FDD4C /* User+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		7207A0C91CEA34E9005FDD4C /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -555,6 +559,8 @@
 		14F3A6A71BE01B9C00789E22 /* TableSwift */ = {
 			isa = PBXGroup;
 			children = (
+				7207A0C81CEA34E9005FDD4C /* User+CoreDataProperties.swift */,
+				7207A0C91CEA34E9005FDD4C /* User.swift */,
 				14F3A6A81BE01B9C00789E22 /* AppDelegate.swift */,
 				14F3A6E81BE01DE800789E22 /* ViewController.swift */,
 				141D2EE31BE021500028F879 /* CustomCell.swift */,
@@ -1076,10 +1082,12 @@
 				14F3A6E91BE01DE800789E22 /* ViewController.swift in Sources */,
 				1498B6121C3BC9E80066FAC8 /* DataModel.xcdatamodeld in Sources */,
 				14308ABD1CC66665000C21DF /* DATASource.swift in Sources */,
+				7207A0CB1CEA34E9005FDD4C /* User.swift in Sources */,
 				141D2EE41BE021500028F879 /* CustomCell.swift in Sources */,
 				14308AAD1CC66665000C21DF /* DATASource+UICollectionViewDataSource.swift in Sources */,
 				14F3A6A91BE01B9C00789E22 /* AppDelegate.swift in Sources */,
 				1498B60B1C3BC9E80066FAC8 /* CollectionCell.swift in Sources */,
+				7207A0CA1CEA34E9005FDD4C /* User+CoreDataProperties.swift in Sources */,
 				1498B6191C3BC9E80066FAC8 /* InfiniteLoadingIndicator.swift in Sources */,
 				14308AC51CC66665000C21DF /* DATASourceCollectionHeaderView.swift in Sources */,
 			);

--- a/Library/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
+++ b/Library/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Automatic">
-    <entity name="User" representedClassName="" syncable="YES">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15E65" minimumToolsVersion="Automatic">
+    <entity name="User" representedClassName=".User" syncable="YES">
         <attribute name="count" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="createdDate" optional="YES" attributeType="Date" syncable="YES"/>
-        <attribute name="firstLetterOfName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="firstLetterOfName" optional="YES" transient="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>

--- a/Source/DATASource+UITableViewDataSource.swift
+++ b/Source/DATASource+UITableViewDataSource.swift
@@ -32,6 +32,11 @@ extension DATASource: UITableViewDataSource {
         } else if let keyPath = self.fetchedResultsController.sectionNameKeyPath {
             let request = NSFetchRequest()
             request.entity = self.fetchedResultsController.fetchRequest.entity
+            if let property = request.entity?.propertiesByName[keyPath] {
+                if property.transient {
+                    return self.fetchedResultsController.sectionIndexTitles
+                }
+            }
             request.resultType = .DictionaryResultType
             request.returnsDistinctResults = true
             request.propertiesToFetch = [keyPath]

--- a/Source/DATASource+UITableViewDataSource.swift
+++ b/Source/DATASource+UITableViewDataSource.swift
@@ -29,37 +29,9 @@ extension DATASource: UITableViewDataSource {
     public func sectionIndexTitlesForTableView(tableView: UITableView) -> [String]? {
         if let titles = self.delegate?.sectionIndexTitlesForDataSource?(self, tableView: tableView) {
             return titles
-        } else if let keyPath = self.fetchedResultsController.sectionNameKeyPath {
-            let request = NSFetchRequest()
-            request.entity = self.fetchedResultsController.fetchRequest.entity
-            if let property = request.entity?.propertiesByName[keyPath] {
-                if property.transient {
-                    return self.fetchedResultsController.sectionIndexTitles
-                }
-            }
-            request.resultType = .DictionaryResultType
-            request.returnsDistinctResults = true
-            request.propertiesToFetch = [keyPath]
-            request.sortDescriptors = [NSSortDescriptor(key: keyPath, ascending: true)]
-            var names = [String]()
-            var objects: [NSDictionary]?
-
-            do {
-                objects = try self.fetchedResultsController.managedObjectContext.executeFetchRequest(request) as? [NSDictionary]
-            } catch {
-                print("Error")
-            }
-
-            if let objects = objects {
-                for object in objects {
-                    names.appendContentsOf(object.allValues as! [String])
-                }
-            }
-
-            return names
+        } else {
+            return self.fetchedResultsController.sectionIndexTitles
         }
-
-        return nil
     }
 
     public func tableView(tableView: UITableView, sectionForSectionIndexTitle title: String, atIndex index: Int) -> Int {

--- a/TableSwift/User+CoreDataProperties.swift
+++ b/TableSwift/User+CoreDataProperties.swift
@@ -1,0 +1,21 @@
+//
+//  User+CoreDataProperties.swift
+//  Demo
+//
+//  Created by Dmitry Zarva on 16/05/16.
+//
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+import Foundation
+import CoreData
+
+extension User {
+
+    @NSManaged var count: NSNumber
+    @NSManaged var createdDate: NSDate?
+    @NSManaged var name: String?
+
+}

--- a/TableSwift/User.swift
+++ b/TableSwift/User.swift
@@ -1,0 +1,19 @@
+//
+//  User.swift
+//  Demo
+//
+//  Created by Dmitry Zarva on 16/05/16.
+//
+//
+
+import Foundation
+import CoreData
+
+
+class User: NSManagedObject {
+
+    var firstLetterOfName: String? {
+        return String(Array(self.name!.characters)[0])
+    }
+
+}

--- a/TableSwift/ViewController.swift
+++ b/TableSwift/ViewController.swift
@@ -8,9 +8,8 @@ class ViewController: UITableViewController {
     lazy var dataSource: DATASource = {
         let request: NSFetchRequest = NSFetchRequest(entityName: "User")
         request.sortDescriptors = [
-            NSSortDescriptor(key: "firstLetterOfName", ascending: true),
+            NSSortDescriptor(key: "name", ascending: true),
             NSSortDescriptor(key: "count", ascending: true),
-            NSSortDescriptor(key: "name", ascending: true)
         ]
 
         let dataSource = DATASource(tableView: self.tableView, cellIdentifier: CustomCell.Identifier, fetchRequest: request, mainContext: self.dataStack!.mainContext, sectionName: "firstLetterOfName") { cell, item, indexPath in
@@ -44,12 +43,10 @@ class ViewController: UITableViewController {
     func saveAction() {
         self.dataStack!.performInNewBackgroundContext { backgroundContext in
             if let entity = NSEntityDescription.entityForName("User", inManagedObjectContext: backgroundContext) {
-                let user = NSManagedObject(entity: entity, insertIntoManagedObjectContext: backgroundContext)
+                let user = NSManagedObject(entity: entity, insertIntoManagedObjectContext: backgroundContext) as! User
 
                 let name = self.randomString()
-                let firstLetter = String(Array(name.characters)[0])
                 user.setValue(name, forKey: "name")
-                user.setValue(firstLetter, forKey: "firstLetterOfName")
 
                 do {
                     try backgroundContext.save()


### PR DESCRIPTION
Fix #69 

See changeset [7351842](https://github.com/3lvis/DATASource/commit/735184266ef5c2b72d34a3ad3340711e84e8cdf1) for reproduce the issue, [555678d](https://github.com/3lvis/DATASource/commit/555678d7535e233af808f43f617c63f0de95b389) - fixes the issue.
But I suppose the default implementation of UITableViewDataSource.sectionIndexTitlesForTableView(_:) should be like in [ea3c945
](https://github.com/3lvis/DATASource/commit/ea3c94577aee58f70c0e1f97f18a0b5db94ddecf)

@3lvis could you please check this out and test with transient and managed properties as well.