### PR TITLE
Avoid weird inconsistency state when data is not valid

### DIFF
--- a/Source/DATASource+NSFetchedResultsControllerDelegate.swift
+++ b/Source/DATASource+NSFetchedResultsControllerDelegate.swift
@@ -162,35 +162,39 @@ extension DATASource: NSFetchedResultsControllerDelegate {
             }
 
             if let collectionView = self.collectionView {
-                collectionView.performBatchUpdates({
-                    if let deletedSections = self.sectionChanges[.Delete] {
-                        collectionView.deleteSections(deletedSections)
-                    }
+                do {
+                    collectionView.performBatchUpdates({
+                        if let deletedSections = self.sectionChanges[.Delete] {
+                            collectionView.deleteSections(deletedSections)
+                        }
 
-                    if let insertedSections = self.sectionChanges[.Insert] {
-                        collectionView.insertSections(insertedSections)
-                    }
+                        if let insertedSections = self.sectionChanges[.Insert] {
+                            collectionView.insertSections(insertedSections)
+                        }
 
-                    if let deleteItems = self.objectChanges[.Delete] {
-                        collectionView.deleteItemsAtIndexPaths(Array(deleteItems))
-                    }
+                        if let deleteItems = self.objectChanges[.Delete] {
+                            collectionView.deleteItemsAtIndexPaths(Array(deleteItems))
+                        }
 
-                    if let insertedItems = self.objectChanges[.Insert] {
-                        collectionView.insertItemsAtIndexPaths(Array(insertedItems))
-                    }
+                        if let insertedItems = self.objectChanges[.Insert] {
+                            collectionView.insertItemsAtIndexPaths(Array(insertedItems))
+                        }
 
-                    if let reloadItems = self.objectChanges[.Update] {
-                        collectionView.reloadItemsAtIndexPaths(Array(reloadItems))
-                    }
+                        if let reloadItems = self.objectChanges[.Update] {
+                            collectionView.reloadItemsAtIndexPaths(Array(reloadItems))
+                        }
 
-                    if let moveItems = self.objectChanges[.Move] {
-                        var generator = moveItems.generate()
-                        guard let fromIndexPath = generator.next() else { fatalError("fromIndexPath not found. Move items: \(moveItems)") }
-                        guard let toIndexPath = generator.next() else { fatalError("toIndexPath not found. Move items: \(moveItems)") }
-                        collectionView.moveItemAtIndexPath(fromIndexPath, toIndexPath: toIndexPath)
-                    }
-
-                    }, completion: nil)
+                        if let moveItems = self.objectChanges[.Move] {
+                            var generator = moveItems.generate()
+                            guard let fromIndexPath = generator.next() else { fatalError("fromIndexPath not found. Move items: \(moveItems)") }
+                            guard let toIndexPath = generator.next() else { fatalError("toIndexPath not found. Move items: \(moveItems)") }
+                            collectionView.moveItemAtIndexPath(fromIndexPath, toIndexPath: toIndexPath)
+                        }
+                        
+                        }, completion: nil)
+                } catch let error as NSError {
+                    fatalError("Failed trying to update the collection view: \(error.description)")
+                }
             }
         }
         self.delegate?.dataSourceDidChangeContent?(self)


### PR DESCRIPTION
When performBatchUpdates fails for any reason, the collection view displays white blocks. The only quick way to fix this is by killing the app.