### PR TITLE
Add reloadCells method

### DIFF
--- a/Source/DATASource.swift
+++ b/Source/DATASource.swift
@@ -233,6 +233,24 @@ public class DATASource: NSObject {
         return self.fetchedResultsController.sections?[section].name
     }
 
+    /**
+     Lightweight replacement for `reloadItemsAtIndexPaths` that doesn't flash the reloaded items.
+     - parameter indexPaths: The array of indexPaths to be reloaded.
+     */
+    public func reloadCells(at indexPaths: [NSIndexPath]) {
+        for indexPath in indexPaths {
+            if let tableView = self.tableView {
+                if let cell = tableView.cellForRowAtIndexPath(indexPath) {
+                    self.configure(cell: cell, indexPath: indexPath)
+                }
+            } else if let collectionView = self.collectionView {
+                if let cell = collectionView.cellForItemAtIndexPath(indexPath) {
+                    self.configure(cell: cell, indexPath: indexPath)
+                }
+            }
+        }
+    }
+
     func configure(cell cell: UIView, indexPath: NSIndexPath) {
         var item: NSManagedObject?
 


### PR DESCRIPTION
`self.collectionView?.reloadItemsAtIndexPaths([indexPath])` is pretty heavy, is usually one of the most heavy operations you can do in a `UICollectionView`. Also when it reloads the cells it flashes or blinks which is a quite terrible effect. This PR adds a better way to reload cells in DATASource.