### PR TITLE
Provide a block free alternative

### DIFF
--- a/Source/DATASource.swift
+++ b/Source/DATASource.swift
@@ -36,6 +36,38 @@ public class DATASource: NSObject {
         self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier);
     }
 
+    /**
+     Initializes and returns a data source object for a table view.
+     - parameter tableView: A table view used to construct the data source.
+     - parameter cellIdentifier: An identifier from the registered UITableViewCell subclass.
+     - parameter fetchRequest: A request to be used, requests need a sort descriptor.
+     - parameter mainContext: A main thread managed object context.
+     - parameter sectionName: The section to be used for generating the section headers. `nil` means no grouping by section is needed.
+     */
+    public convenience init(tableView: UITableView, cellIdentifier: String, fetchRequest: NSFetchRequest, mainContext: NSManagedObjectContext, sectionName: String? = nil) {
+        self.init(cellIdentifier: cellIdentifier, fetchRequest: fetchRequest, mainContext: mainContext, sectionName: sectionName, tableConfiguration: nil, collectionConfiguration: nil)
+
+        self.tableView = tableView
+        self.tableView?.dataSource = self
+    }
+
+    /**
+     Initializes and returns a data source object for a collection view.
+     - parameter collectionView: A collection view used to construct the data source.
+     - parameter cellIdentifier: An identifier from the registered UICollectionViewCell subclass.
+     - parameter fetchRequest: A request to be used, requests need a sort descriptor.
+     - parameter mainContext: A main thread managed object context.
+     - parameter sectionName: The section to be used for generating the section headers. `nil` means no grouping by section is needed.
+     */
+    public convenience init(collectionView: UICollectionView, cellIdentifier: String, fetchRequest: NSFetchRequest, mainContext: NSManagedObjectContext, sectionName: String? = nil) {
+        self.init(cellIdentifier: cellIdentifier, fetchRequest: fetchRequest, mainContext: mainContext, sectionName: sectionName, tableConfiguration: nil, collectionConfiguration: nil)
+
+        self.collectionView = collectionView
+        self.collectionView?.dataSource = self
+
+        self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier);
+    }
+
     private init(cellIdentifier: String, fetchRequest: NSFetchRequest, mainContext: NSManagedObjectContext, sectionName: String? = nil, tableConfiguration: ((cell: UITableViewCell, item: NSManagedObject, indexPath: NSIndexPath) -> ())?, collectionConfiguration: ((cell: UICollectionViewCell, item: NSManagedObject, indexPath: NSIndexPath) -> ())?) {
         self.cellIdentifier = cellIdentifier
         self.fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: mainContext, sectionNameKeyPath: sectionName, cacheName: nil)
@@ -260,10 +292,22 @@ public class DATASource: NSObject {
         }
 
         if let item = item {
-            if let _ = self.tableView, configuration = self.tableConfigurationBlock {
-                configuration(cell: cell as! UITableViewCell, item: item, indexPath: indexPath)
-            } else if let _ = self.collectionView, configuration = self.collectionConfigurationBlock {
-                configuration(cell: cell as! UICollectionViewCell, item: item, indexPath: indexPath)
+            if let _ = self.tableView {
+                if let configuration = self.tableConfigurationBlock {
+                    configuration(cell: cell as! UITableViewCell, item: item, indexPath: indexPath)
+                } else if self.delegate?.respondsToSelector(#selector(DATASourceDelegate.dataSource(_:configureTableViewCell:withItem:atIndexPath:))) != nil {
+                    self.delegate?.dataSource?(self, configureTableViewCell: cell as! UITableViewCell, withItem: item, atIndexPath: indexPath)
+                } else {
+                    fatalError()
+                }
+            } else if let _ = self.collectionView {
+                if let configuration = self.collectionConfigurationBlock {
+                    configuration(cell: cell as! UICollectionViewCell, item: item, indexPath: indexPath)
+                } else if self.delegate?.respondsToSelector(#selector(DATASourceDelegate.dataSource(_:configureCollectionViewCell:withItem:atIndexPath:))) != nil {
+                    self.delegate?.dataSource?(self, configureCollectionViewCell: cell as! UICollectionViewCell, withItem: item, atIndexPath: indexPath)
+                } else {
+                    fatalError()
+                }
             }
         }
     }

--- a/Source/DATASource.swift
+++ b/Source/DATASource.swift
@@ -33,7 +33,7 @@ public class DATASource: NSObject {
         self.collectionView = collectionView
         self.collectionView?.dataSource = self
 
-        self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier);
+        self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier)
     }
 
     /**
@@ -65,7 +65,7 @@ public class DATASource: NSObject {
         self.collectionView = collectionView
         self.collectionView?.dataSource = self
 
-        self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier);
+        self.collectionView?.registerClass(DATASourceCollectionViewHeader.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader, withReuseIdentifier: DATASourceCollectionViewHeader.Identifier)
     }
 
     private init(cellIdentifier: String, fetchRequest: NSFetchRequest, mainContext: NSManagedObjectContext, sectionName: String? = nil, tableConfiguration: ((cell: UITableViewCell, item: NSManagedObject, indexPath: NSIndexPath) -> ())?, collectionConfiguration: ((cell: UICollectionViewCell, item: NSManagedObject, indexPath: NSIndexPath) -> ())?) {

--- a/Source/DATASourceDelegate.swift
+++ b/Source/DATASourceDelegate.swift
@@ -2,6 +2,23 @@ import UIKit
 import CoreData
 
 @objc public protocol DATASourceDelegate: NSObjectProtocol {
+    /*!
+     * **************************
+     *
+     * Cell Configuration
+     *
+     * **************************
+     */
+    optional func dataSource(dataSource: DATASource, configureTableViewCell cell: UITableViewCell, withItem item: NSManagedObject, atIndexPath indexPath: NSIndexPath)
+    optional func dataSource(dataSource: DATASource, configureCollectionViewCell cell: UICollectionViewCell, withItem item: NSManagedObject, atIndexPath indexPath: NSIndexPath)
+
+    /*!
+     * **************************
+     *
+     * NSFetchedResultsControllerDelegate
+     *
+     * **************************
+     */
     optional func dataSource(dataSource: DATASource, didInsertObject object: NSManagedObject, atIndexPath indexPath: NSIndexPath)
     optional func dataSource(dataSource: DATASource, didUpdateObject object: NSManagedObject, atIndexPath indexPath: NSIndexPath)
     optional func dataSource(dataSource: DATASource, didDeleteObject object: NSManagedObject, atIndexPath indexPath: NSIndexPath)
@@ -11,7 +28,7 @@ import CoreData
     /*!
     * **************************
     *
-    * UITableView specific
+    * UITableView
     *
     * **************************
     */
@@ -36,7 +53,7 @@ import CoreData
     /*!
     * **************************
     *
-    * UICollectionView specific
+    * UICollectionView
     *
     * **************************
     */

--- a/TableSwift/ViewController.swift
+++ b/TableSwift/ViewController.swift
@@ -13,13 +13,8 @@ class ViewController: UITableViewController {
             NSSortDescriptor(key: "name", ascending: true)
         ]
 
-        let dataSource = DATASource(tableView: self.tableView, cellIdentifier: CustomCell.Identifier, fetchRequest: request, mainContext: self.dataStack!.mainContext, sectionName: "firstLetterOfName") { cell, item, indexPath in
-            if let cell = cell as? CustomCell {
-                let name = item.valueForKey("name") as? String ?? ""
-                let count = item.valueForKey("count") as? Int ?? 0
-                cell.label.text = "\(count) — \(name)"
-            }
-        }
+        let dataSource = DATASource(tableView: self.tableView, cellIdentifier: CustomCell.Identifier, fetchRequest: request, mainContext: self.dataStack!.mainContext, sectionName: "firstLetterOfName")
+        dataSource.delegate = self
 
         return dataSource
     }()
@@ -86,6 +81,16 @@ class ViewController: UITableViewController {
             count += 1
             user.setValue(count, forKey: "count")
             try! backgroundContext.save()
+        }
+    }
+}
+
+extension ViewController: DATASourceDelegate {
+    func dataSource(dataSource: DATASource, configureTableViewCell cell: UITableViewCell, withItem item: NSManagedObject, atIndexPath indexPath: NSIndexPath) {
+        if let cell = cell as? CustomCell {
+            let name = item.valueForKey("name") as? String ?? ""
+            let count = item.valueForKey("count") as? Int ?? 0
+            cell.label.text = "\(count) — \(name)"
         }
     }
 }


### PR DESCRIPTION
Using blocks for the cell configuration is not the best idea. The initial reason why I went for that alternative was because I didn't liked the other alternative: using a delegate for the cell configuration.
Specially since that would mean that you could use a **DATASource** instance that did nothing since the configuration block wasn't provided by default.

But I was wrong, even though is not the best paradigm, is a common paradigm. For example you can easily instantiate a `UITableView` that does nothing. You have to actually implement it's data source before it can display data. It's a common paradigm, not the best, but is not rare neither.

To not break all the existing apps that are using **DATASource** right now, I'm providing this implementation as an alternative instead of a replacement.

So now you can do:

```swift
class ViewController: UITableViewController {
    weak var dataStack: DATAStack?

    convenience init(dataStack: DATAStack) {
        self.init(style: .Plain)

        self.dataStack = dataStack
    }
    lazy var dataSource: DATASource = {
        let request: NSFetchRequest = NSFetchRequest(entityName: "User")
        request.sortDescriptors = [
            NSSortDescriptor(key: "name", ascending: true)
        ]

        let dataSource = DATASource(tableView: self.tableView, cellIdentifier: CustomCell.Identifier, fetchRequest: request, mainContext: self.dataStack!.mainContext)
        dataSource.delegate = self

        return dataSource
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        self.tableView.dataSource = self.dataSource
}

extension ViewController: DATASourceDelegate {
    func dataSource(dataSource: DATASource, configureTableViewCell cell: UITableViewCell, withItem item: NSManagedObject, atIndexPath indexPath: NSIndexPath) {
        cell.textLabel.text = item.valueForKey("name") as? String ?? ""
    }
}
```