### PR TITLE
Fix update instead of move

### DIFF
--- a/Source/DATASource+NSFetchedResultsControllerDelegate.swift
+++ b/Source/DATASource+NSFetchedResultsControllerDelegate.swift
@@ -75,11 +75,24 @@ extension DATASource: NSFetchedResultsControllerDelegate {
                 break
             case .move:
                 if let indexPath = indexPath, let newIndexPath = newIndexPath {
-                    tableView.deleteRows(at: [indexPath], with: rowAnimationType)
-                    tableView.insertRows(at: [newIndexPath], with: rowAnimationType)
+                    // Workaround: Updating a UICollectionView element sometimes will trigger a .Move change
+                    // where both indexPaths are the same, as a workaround if this happens, DATASource
+                    // will treat this change as an .Update
+                    if indexPath == newIndexPath {
+                        if let cell = tableView.cellForRow(at: newIndexPath) {
+                            self.configure(cell, indexPath: newIndexPath)
+                        }
 
-                    if let anObject = anObject as? NSManagedObject {
-                        self.delegate?.dataSource?(self, didMoveObject: anObject, fromIndexPath: indexPath, toIndexPath: newIndexPath)
+                        if let anObject = anObject as? NSManagedObject {
+                            self.delegate?.dataSource?(self, didUpdateObject: anObject, atIndexPath: newIndexPath)
+                        }
+                    } else {
+                        tableView.deleteRows(at: [indexPath], with: rowAnimationType)
+                        tableView.insertRows(at: [newIndexPath], with: rowAnimationType)
+
+                        if let anObject = anObject as? NSManagedObject {
+                            self.delegate?.dataSource?(self, didMoveObject: anObject, fromIndexPath: indexPath, toIndexPath: newIndexPath)
+                        }
                     }
                 }
                 break


### PR DESCRIPTION
For a CollectionView there was already a workaround in place, but it turns out the same can happen for tablieViews. Therefore I implemented the same workaround to solve this issue